### PR TITLE
Json rewrite

### DIFF
--- a/moxxiconf/config.go
+++ b/moxxiconf/config.go
@@ -122,6 +122,16 @@ func validateConfig(dirtyConfig *map[string]interface{}) Err {
 		}
 	}
 
+	if _, ok := c["redirectTracing"]; ok {
+		if _, ok = c["redirectTracing"].(bool); !ok {
+			return NewErr{
+				Code:    ErrConfigBadStructure,
+				value:   "redirectTracing",
+				deepErr: fmt.Errorf("%T - %#v", c["redirectTracing"], c["redirectTracing"]),
+			}
+		}
+	}
+
 	// verify the handlers are an array
 	handlers, ok := c["handler"].([]interface{})
 	if !ok {
@@ -256,6 +266,20 @@ func validateConfigHandler(pConfig *map[string]interface{}, id int) Err {
 		}
 	}
 
+	if _, ok = h["redirectTracing"]; ok {
+		if _, ok = h["redirectTracing"].(bool); !ok {
+			return NewErr{
+				Code:    ErrConfigBadStructure,
+				value:   "redirectTracing",
+				deepErr: fmt.Errorf("%T - %#v", c["redirectTracing"], c["redirectTracing"]),
+			}
+		}
+	} else {
+		if _, ok := c["redirectTracing"]; ok {
+			h["redirectTracing"] = c["redirectTracing"]
+		}
+	}
+
 	// pack things back in
 	allHandlers[id] = h
 	c["handler"] = allHandlers
@@ -383,6 +407,15 @@ func decodeHandler(dirtyHandler interface{}) (HandlerConfig, Err) {
 			return HandlerConfig{}, NewErr{
 				Code:  ErrConfigLoadValue,
 				value: "subdomainLen",
+			}
+		}
+	}
+
+	if _, ok = addressed["redirectTracing"]; ok {
+		if h.redirectTracing, ok = addressed["redirectTracing"].(bool); !ok {
+			return HandlerConfig{}, NewErr{
+				Code:  ErrConfigLoadValue,
+				value: "redirectTracing",
 			}
 		}
 	}

--- a/moxxiconf/error.go
+++ b/moxxiconf/error.go
@@ -101,6 +101,7 @@ const (
 	ErrConfigLoadValue
 	ErrConfigLoadTemplate
 	ErrConfigBadIPFile
+	ErrBadHostnameTrace
 )
 
 // specify the error message for each error
@@ -128,4 +129,5 @@ var errMsg = map[int]string{
 	ErrConfigLoadValue:     "bad config load - %s is not present",
 	ErrConfigLoadTemplate:  "bad config load at %s - %v",
 	ErrConfigBadIPFile:     "bad ip file - %s - %v",
+	ErrBadHostnameTrace:    "unable to trace out domain %s - %v",
 }

--- a/moxxiconf/type.go
+++ b/moxxiconf/type.go
@@ -41,19 +41,20 @@ func init() {
 }
 
 type HandlerConfig struct {
-	handlerType  string
-	handlerRoute string
-	baseURL      string
-	confPath     string
-	confExt      string
-	exclude      []string
-	confFile     string
-	confTempl    *template.Template
-	resFile      string
-	resTempl     *template.Template
-	ipFile       string
-	ipList       []*net.IPNet
-	subdomainLen int
+	handlerType     string
+	handlerRoute    string
+	baseURL         string
+	confPath        string
+	confExt         string
+	redirectTracing bool
+	exclude         []string
+	confFile        string
+	confTempl       *template.Template
+	resFile         string
+	resTempl        *template.Template
+	ipFile          string
+	ipList          []*net.IPNet
+	subdomainLen    int
 }
 
 // everything below this line can likely go?

--- a/moxxiconf/writer.go
+++ b/moxxiconf/writer.go
@@ -2,9 +2,12 @@ package moxxiConf
 
 import (
 	"bufio"
+	"fmt"
 	"github.com/dchest/uniuri"
 	"net"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -36,29 +39,37 @@ func validHost(s string) string {
 	return strings.Join(parts, DomainSep)
 }
 
-func confCheck(host, ip string, destTLS bool, port int,
-	blockedHeaders []string, ipList []*net.IPNet) (siteParams, Err) {
+func confCheck(proxy siteParams, config HandlerConfig) (siteParams, Err) {
 	var conf siteParams
-	if conf.IntHost = validHost(host); conf.IntHost == "" {
-		return siteParams{}, &NewErr{Code: ErrBadHost, value: host}
+	if conf.IntHost = validHost(proxy.IntHost); conf.IntHost == "" {
+		return siteParams{}, &NewErr{Code: ErrBadHost, value: proxy.IntHost}
 	}
 
-	tempIP := net.ParseIP(ip)
+	tempIP := net.ParseIP(proxy.IntIP)
 	if tempIP == nil {
-		return siteParams{}, &NewErr{Code: ErrBadIP, value: ip}
+		return siteParams{}, &NewErr{Code: ErrBadIP, value: proxy.IntIP}
 	}
-	if len(ipList) > 0 && !ipListContains(tempIP, ipList) {
+	if len(config.ipList) > 0 && !ipListContains(tempIP, config.ipList) {
 		return siteParams{}, &NewErr{Code: ErrBlockedIP, value: tempIP.String()}
 	}
 
 	conf.IntPort = 80
-	if port > 0 && port < MaxAllowedPort {
-		conf.IntPort = port
+	if proxy.IntPort > 0 && proxy.IntPort < MaxAllowedPort {
+		conf.IntPort = proxy.IntPort
 	}
 
 	conf.IntIP = tempIP.String()
-	conf.Encrypted = destTLS
-	conf.StripHeaders = blockedHeaders
+	conf.Encrypted = proxy.Encrypted
+	conf.StripHeaders = proxy.StripHeaders
+
+	if config.redirectTracing {
+		newIntHost, newIntPort, newEncrypted, err := redirectTrace(conf.IntHost, conf.IntPort, conf.Encrypted)
+		if err == nil {
+			conf.IntHost = newIntHost
+			conf.IntPort = newIntPort
+			conf.Encrypted = newEncrypted
+		}
+	}
 
 	return conf, nil
 }
@@ -173,4 +184,70 @@ func ipListContains(address net.IP, list []*net.IPNet) bool {
 		}
 	}
 	return false
+}
+
+func redirectTrace(initHost string, initPort int, initTLS bool) (string, int, bool, Err) {
+
+	var initURL string
+	if initTLS {
+		initURL = (fmt.Sprintf("https://%s:%d/", initHost, initPort))
+	} else {
+		initURL = (fmt.Sprintf("http://%s:%d/", initHost, initPort))
+	}
+
+	resp, err := http.Head(initURL)
+	if err != nil {
+		return "", 0, false, NewErr{
+			Code:    ErrBadHostnameTrace,
+			value:   initURL,
+			deepErr: err,
+		}
+	}
+
+	var respHost string
+	var respPort int
+	var respTLS bool
+
+	if resp.Request == nil {
+		return "", 0, false, NewErr{
+			Code:    ErrBadHostnameTrace,
+			value:   initURL,
+			deepErr: fmt.Errorf("did not get a request back from %s", initURL),
+		}
+	}
+
+	var hostname string
+	if resp.Request.Host != "" {
+		hostname = resp.Request.Host
+	} else if resp.Request.URL != nil {
+		hostname = resp.Request.URL.Host
+	} else {
+		return "", 0, false, NewErr{
+			Code:    ErrBadHostnameTrace,
+			value:   initURL,
+			deepErr: fmt.Errorf("cound not find the URL"),
+		}
+	}
+
+	if strings.Contains(hostname, ":") {
+		parts := strings.Split(hostname, ":")
+		respPort, err = strconv.Atoi(parts[len(parts)-1])
+		if err != nil {
+			respHost = resp.Request.Host
+		} else {
+			respHost = strings.Join(parts[:len(parts)-1], ":")
+		}
+	} else {
+		respHost = hostname
+		if resp.TLS == nil {
+			respPort = 80
+		} else {
+			respPort = 443
+		}
+	}
+	if resp.Request.TLS != nil {
+		respTLS = true
+	}
+
+	return respHost, respPort, respTLS, nil
 }

--- a/moxxiconf/writer_test.go
+++ b/moxxiconf/writer_test.go
@@ -122,8 +122,8 @@ func TestConfCheck(t *testing.T) {
 	}
 
 	for _, test := range testData {
-		eachOut, eachErr := confCheck(test.host, test.ip, test.destTLS,
-			test.port, test.blockedHeaders, []*net.IPNet{})
+		vhostConf := siteParams{IntHost: test.host, IntPort: test.port, Encrypted: test.destTLS, IntIP: test.ip, StripHeaders: test.blockedHeaders}
+		eachOut, eachErr := confCheck(vhostConf, HandlerConfig{})
 		assert.Equal(t, test.exp, eachOut, "expected return and actual did not match")
 		assert.Equal(t, test.expErr, eachErr, "expected return and actual did not match")
 	}
@@ -343,4 +343,50 @@ func TestParseIPList_BadFile(t *testing.T) {
 
 	_, locErr := parseIPList(fileName)
 	assert.Equal(t, ErrConfigBadIPFile, locErr.GetCode(), "got the wrong error type back")
+}
+
+func TestRedirectTrace(t *testing.T) {
+	var testData = []struct {
+		hostIn  string
+		portIn  int
+		tlsIn   bool
+		hostOut string
+		portOut int
+		tlsOut  bool
+	}{
+		{
+			hostIn:  "google.com",
+			portIn:  80,
+			tlsIn:   false,
+			hostOut: "www.google.com",
+			portOut: 80,
+			tlsOut:  false,
+		}, {
+			hostIn:  "github.com",
+			portIn:  80,
+			tlsIn:   false,
+			hostOut: "github.com",
+			portOut: 443,
+			tlsOut:  true,
+		}, {
+			hostIn:  "facebook.com",
+			portIn:  80,
+			tlsIn:   false,
+			hostOut: "www.facebook.com",
+			portOut: 443,
+			tlsOut:  true,
+		},
+	}
+
+	for id, test := range testData {
+		hostRes, portRes, tlsRes, err := redirectTrace(test.hostIn, test.portIn, test.tlsIn)
+		assert.Nil(t, err,
+			"test %d - got an error back that I should not have\n%v", id, err)
+		assert.Equal(t, test.hostOut, hostRes,
+			"test %d - got the wrong/unexpected host back", id)
+		assert.Equal(t, test.portOut, portRes,
+			"test %d - got the wrong/unexpected port back", id)
+		assert.Equal(t, test.tlsOut, tlsRes,
+			"test %d - got the wrong/unexpected encryption back", id)
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -15,36 +15,34 @@ JSON Format
 JSON requests should be laid out as follows - just included here:
 
 ```json
-[
-  {
-    "host": "hostname",
-    "ip": "serverIP",
-    "port": 443,
-    "tls": true,
-    "blockedHeaders": [
-      "X-Frame-Options",
-      "Accept-Encoding"
-    ]
-  },
-  {
-    "host": "hostbaitor.com",
-    "ip": "72.52.161.205",
-    "port": 80,
-    "tls": false,
-    "blockedHeaders": [
-      "X-Frame-Options",
-      "Accept-Encoding"
-    ]
-  },
-  {
-    "host": "deleteos.com",
-    "ip": "deleteos.com",
-    "port": 443,
-    "tls": true,
-    "blockedHeaders": [
-      "X-Frame-Options",
-      "Accept-Encoding"
-    ]
-  }
-]
+{
+  "host": "hostname",
+  "ip": "serverIP",
+  "port": 443,
+  "tls": true,
+  "blockedHeaders": [
+    "X-Frame-Options",
+    "Accept-Encoding"
+  ]
+},
+{
+  "host": "hostbaitor.com",
+  "ip": "72.52.161.205",
+  "port": 80,
+  "tls": false,
+  "blockedHeaders": [
+    "X-Frame-Options",
+    "Accept-Encoding"
+  ]
+},
+{
+  "host": "deleteos.com",
+  "ip": "deleteos.com",
+  "port": 443,
+  "tls": true,
+  "blockedHeaders": [
+    "X-Frame-Options",
+    "Accept-Encoding"
+  ]
+}
 ```

--- a/response.template
+++ b/response.template
@@ -1,15 +1,22 @@
+{{- define tStart -}}
 <html>
 	<head>
 		<title>
 		</title>
 	</head>
 	<body>
-		{{ with . }}
 		<table>
-			{{ range . }}
+{{end}}
+
+{{ define tBody }}
+	{{ with . }}
 			<tr>
 				<td>
+				{{ if .Encrypted }} 
+					<a href="https://{{ .ExtHost }}">{{ .ExtHost }}</a>
+				{{ else }}
 					<a href="http://{{ .ExtHost }}">{{ .ExtHost }}</a>
+				{{ end }}
 				</td>
 				<td>
 					{{ .IntHost }}
@@ -27,15 +34,65 @@
 				{{ with .StripHeaders }}
 				<td>
 					{{ range .StripHeaders }}
-					<div class="killedHeader">
+					<div class="stripHeader">
 						{{ . }}
 					</div>
 					{{ end}}
 				</td>
 				{{ end }}
 			</tr>
-			{{ end }}
+	{{ end }}
+{{ end }}
+
+{{ define tEnd }}
 		</table>
-		{{ end }}
 	</body>
 </html>
+{{ end }}
+
+{{ define tError }}
+	{{ with . }}
+			<tr>
+				<td>
+					FAILURE
+				</td>
+				<td>
+					{{ .IntHost }}
+				</td>
+				<td>
+					{{ .IntIP }}
+				</td>
+				<td>
+					{{ if .Encrypted }}
+					Encryption enabled
+					{{ else }}
+					Encryption disabled
+					{{ end }}
+				</td>
+				{{ with .StripHeaders }}
+				<td>
+					{{ range . }}
+					<div class="stripHeader">
+						{{ . }}
+					</div>
+					{{ end}}
+				</td>
+				{{ end }}
+				{{ with .myError }}
+					{{ . }}
+				{{ end }}
+			</tr>
+	{{ end }}
+{{ end }}
+
+{{ define tAll }}
+	{{ template tStart}}
+	{{ with . }}
+		{{ range . }}
+			{{ template tBody }}
+		{{ end }}
+	{{ end }}
+	{{ template tEnd }}
+{{ end }}
+
+{{ template tAll }}


### PR DESCRIPTION
rewrote the json handler to take the response in chunks, instead of taking it all at once

should drop memory usage on that handler to under maybe 50M total, under 1M per handler thread.